### PR TITLE
Add 'Time of Day Clock Failure message' support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,10 @@
 #Gradle related
 .gradle/
 **/build
-**/out
-**/allure-results
-.allure
+
 
 # IntelliJ IDEA
+**/out
 .idea/
 *.iml
 *.iws

--- a/examples/src/main/java/io/github/jokoroukwu/examples/central/ProcessCentralMessageExample.java
+++ b/examples/src/main/java/io/github/jokoroukwu/examples/central/ProcessCentralMessageExample.java
@@ -7,7 +7,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 
 public class ProcessCentralMessageExample {
-    //  This is the main entrypoint for central originated messages.
+    //  CentralMessagePreProcessor is the main entrypoint for central originated messages.
     private static final CentralMessagePreProcessor CENTRAL_MESSAGE_PRE_PROCESSOR
             = new CentralMessagePreProcessor(new LoggingCentralMessageListener(), new FakeDeviceConfigurationSupplier());
 
@@ -19,7 +19,7 @@ public class ProcessCentralMessageExample {
         CENTRAL_MESSAGE_PRE_PROCESSOR.processMessage(ndcCharBuffer);
     }
 
-    //  pretend this are message bytes received from some ATM
+    //  pretend these are message bytes received from some ATM
     private static byte[] getRawMessage() {
         return "80\u001C000\u001C4\u001C77099F1A0206439F350114".getBytes(StandardCharsets.US_ASCII);
     }

--- a/examples/src/main/java/io/github/jokoroukwu/examples/terminal/LoggingTerminalMessageListener.java
+++ b/examples/src/main/java/io/github/jokoroukwu/examples/terminal/LoggingTerminalMessageListener.java
@@ -13,6 +13,7 @@ import io.github.jokoroukwu.jndc.terminal.statusmessage.readyb.ReadyBStatus;
 import io.github.jokoroukwu.jndc.terminal.statusmessage.solicited.terminalstate.supplycountersbasic.SupplyCountersBasic;
 import io.github.jokoroukwu.jndc.terminal.statusmessage.solicited.terminalstate.supplycountersextended.SupplyCountersExtended;
 import io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.UnsolicitedStatusMessage;
+import io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.timeofdayclock.TimeOfDayClockFailure;
 import io.github.jokoroukwu.jndc.terminal.transactionrequestmessage.TransactionRequestMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -88,5 +89,10 @@ public class LoggingTerminalMessageListener implements TerminalMessageListener {
     @Override
     public void onSupplyCountersExtendedMessage(SolicitedStatusMessage<SupplyCountersExtended> message) {
         LOGGER.info("Supply Counters Extended message received: {}", message);
+    }
+
+    @Override
+    public void onTimeOfDayClockFailureMessage(UnsolicitedStatusMessage<TimeOfDayClockFailure> message) {
+        LOGGER.info("Time of Day Clock Failure Unsolicited Status message received: {}", message);
     }
 }

--- a/examples/src/main/java/io/github/jokoroukwu/examples/terminal/ProcessTerminalMessageExample.java
+++ b/examples/src/main/java/io/github/jokoroukwu/examples/terminal/ProcessTerminalMessageExample.java
@@ -7,7 +7,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 
 public class ProcessTerminalMessageExample {
-    //  This is the main entrypoint for terminal originated messages.
+    //  TerminalMessagePreProcessor is the main entrypoint for terminal originated messages.
     private static final TerminalMessagePreProcessor TERMINAL_MESSAGE_PRE_PROCESSOR
             = new TerminalMessagePreProcessor(new LoggingTerminalMessageListener(), new FakeDeviceConfigurationSupplier());
 
@@ -18,7 +18,7 @@ public class ProcessTerminalMessageExample {
         TERMINAL_MESSAGE_PRE_PROCESSOR.processMessage(ndcCharBuffer);
     }
 
-    //  pretend this are message bytes received from some ATM.
+    //  pretend these are message bytes received from some ATM.
     private static byte[] getRawMessage() {
         final String message = "11" +
                 "\u001C444555444" +

--- a/jndc/src/main/java/io/github/jokoroukwu/jndc/terminal/TerminalMessageListener.java
+++ b/jndc/src/main/java/io/github/jokoroukwu/jndc/terminal/TerminalMessageListener.java
@@ -23,6 +23,8 @@ import io.github.jokoroukwu.jndc.terminal.statusmessage.solicited.terminalstate.
 import io.github.jokoroukwu.jndc.terminal.statusmessage.solicited.terminalstate.supplycountersextended.SupplyCountersExtended;
 import io.github.jokoroukwu.jndc.terminal.statusmessage.solicited.terminalstate.supplycountersextended.SupplyCountersExtendedMessageListener;
 import io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.UnsolicitedStatusMessage;
+import io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.timeofdayclock.TimeOfDayClockFailure;
+import io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.timeofdayclock.TimeOfDayClockFailureMessageListener;
 import io.github.jokoroukwu.jndc.terminal.transactionrequestmessage.TransactionRequestMessage;
 import io.github.jokoroukwu.jndc.terminal.transactionrequestmessage.TransactionRequestMessageListener;
 
@@ -30,7 +32,7 @@ public interface TerminalMessageListener extends TransactionRequestMessageListen
         UnsolicitedCardReaderWriterFaultMessageListener, EncryptorInitialisationDataMessageListener,
         SupplyCountersBasicMessageListener, SupplyCountersExtendedMessageListener, ReadyBStatusMessageListener,
         CommandRejectStatusMessageListener, ReadyStatusMessageListener, GenericSolicitedStatusMessageListener,
-        SolicitedGenericDeviceFaultMessageListener, SolicitedCardReaderWriterFaultMessageListener {
+        SolicitedGenericDeviceFaultMessageListener, SolicitedCardReaderWriterFaultMessageListener, TimeOfDayClockFailureMessageListener {
 
     @Override
     default void onTransactionRequestMessage(TransactionRequestMessage message) {
@@ -93,6 +95,11 @@ public interface TerminalMessageListener extends TransactionRequestMessageListen
 
     @Override
     default void onSupplyCountersExtendedMessage(SolicitedStatusMessage<SupplyCountersExtended> message) {
+
+    }
+
+    @Override
+    default void onTimeOfDayClockFailureMessage(UnsolicitedStatusMessage<TimeOfDayClockFailure> message) {
 
     }
 }

--- a/jndc/src/main/java/io/github/jokoroukwu/jndc/terminal/statusmessage/UnsolicitedStatusMessageAppender.java
+++ b/jndc/src/main/java/io/github/jokoroukwu/jndc/terminal/statusmessage/UnsolicitedStatusMessageAppender.java
@@ -14,6 +14,7 @@ import io.github.jokoroukwu.jndc.terminal.statusmessage.devicefault.genericfault
 import io.github.jokoroukwu.jndc.terminal.statusmessage.devicefault.genericfault.UnsolicitedGenericDeviceFaultMessageListener;
 import io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.UnsolicitedStatusInformation;
 import io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.UnsolicitedStatusMessageBuilder;
+import io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.timeofdayclock.TimeOfDayClockFailureAppender;
 import io.github.jokoroukwu.jndc.util.ObjectUtils;
 
 import java.util.EnumMap;
@@ -44,6 +45,7 @@ public class UnsolicitedStatusMessageAppender implements NdcComponentAppender<Te
         final Map<Dig, ConfigurableNdcComponentAppender<UnsolicitedStatusMessageBuilder<UnsolicitedStatusInformation>>> appenderMap
                 = new EnumMap<>(Dig.class);
         appenderMap.put(Dig.MAGNETIC_CARD_READER_WRITER, new UnsolicitedCardReaderWriterFaultAppender(messageListener));
+        appenderMap.put(Dig.TIME_OF_DAY_CLOCK, new TimeOfDayClockFailureAppender(messageListener));
         putGenericAppenders(appenderMap, messageListener);
 
         appenderFactory = new ConfigurableNdcComponentAppenderFactoryBase<>(appenderMap);
@@ -53,7 +55,7 @@ public class UnsolicitedStatusMessageAppender implements NdcComponentAppender<Te
             ConfigurableNdcComponentAppender<UnsolicitedStatusMessageBuilder<UnsolicitedStatusInformation>>> appenderMap,
                                             UnsolicitedGenericDeviceFaultMessageListener messageListener) {
 
-        for (Dig dig : EnumSet.complementOf(EnumSet.of(Dig.MAGNETIC_CARD_READER_WRITER))) {
+        for (Dig dig : EnumSet.complementOf(EnumSet.of(Dig.TIME_OF_DAY_CLOCK, Dig.MAGNETIC_CARD_READER_WRITER))) {
             appenderMap.put(dig, new UnsolicitedGenericDeviceFaultAppender(dig, messageListener));
         }
     }

--- a/jndc/src/main/java/io/github/jokoroukwu/jndc/terminal/statusmessage/devicefault/ErrorSeverity.java
+++ b/jndc/src/main/java/io/github/jokoroukwu/jndc/terminal/statusmessage/devicefault/ErrorSeverity.java
@@ -11,9 +11,11 @@ public enum ErrorSeverity implements NdcComponent {
     FATAL('4');
 
     private final char value;
+    private final String displayedName;
 
     ErrorSeverity(char value) {
         this.value = value;
+        displayedName = String.format("%s ('%c')", name(), value);
     }
 
     public static DescriptiveOptional<ErrorSeverity> forValue(char value) {
@@ -49,4 +51,8 @@ public enum ErrorSeverity implements NdcComponent {
     }
 
 
+    @Override
+    public String toString() {
+        return displayedName;
+    }
 }

--- a/jndc/src/main/java/io/github/jokoroukwu/jndc/terminal/statusmessage/devicefault/cardreader/CardReaderWriterAdditionalDataAppender.java
+++ b/jndc/src/main/java/io/github/jokoroukwu/jndc/terminal/statusmessage/devicefault/cardreader/CardReaderWriterAdditionalDataAppender.java
@@ -10,6 +10,8 @@ import io.github.jokoroukwu.jndc.trackdata.TrackDataReader;
 import io.github.jokoroukwu.jndc.util.ObjectUtils;
 import io.github.jokoroukwu.jndc.util.optional.DescriptiveOptional;
 
+import static io.github.jokoroukwu.jndc.exception.NdcMessageParseException.withMessage;
+
 public class CardReaderWriterAdditionalDataAppender implements ConfigurableNdcComponentAppender<CardReaderWriterFaultBuilder> {
     private final NdcComponentReader<DescriptiveOptional<String>> track1DataReader;
     private final NdcComponentReader<DescriptiveOptional<String>> track2DataReader;
@@ -36,13 +38,16 @@ public class CardReaderWriterAdditionalDataAppender implements ConfigurableNdcCo
                     .ifPresent(errorMessage
                             -> NdcMessageParseException.onNoFieldSeparator(UnsolicitedStatusMessage.COMMAND_NAME, "'Additional Data'", errorMessage, ndcCharBuffer));
             final String track1Data = track1DataReader.readComponent(ndcCharBuffer)
-                    .getOrThrow(errorMessage -> NdcMessageParseException.withMessage(UnsolicitedStatusMessage.COMMAND_NAME, "'Track 1 Data'", errorMessage, ndcCharBuffer));
+                    .getOrThrow(errorMessage
+                            -> withMessage(UnsolicitedStatusMessage.COMMAND_NAME, "'Track 1 Data'", errorMessage, ndcCharBuffer));
 
             final String track2Data = track2DataReader.readComponent(ndcCharBuffer)
-                    .getOrThrow(errorMessage -> NdcMessageParseException.withMessage(UnsolicitedStatusMessage.COMMAND_NAME, "'Track 2 Data'", errorMessage, ndcCharBuffer));
+                    .getOrThrow(errorMessage
+                            -> withMessage(UnsolicitedStatusMessage.COMMAND_NAME, "'Track 2 Data'", errorMessage, ndcCharBuffer));
 
             final String track3Data = track3DataReader.readComponent(ndcCharBuffer)
-                    .getOrThrow(errorMessage -> NdcMessageParseException.withMessage(UnsolicitedStatusMessage.COMMAND_NAME, "'Track 3 Data'", errorMessage, ndcCharBuffer));
+                    .getOrThrow(errorMessage
+                            -> withMessage(UnsolicitedStatusMessage.COMMAND_NAME, "'Track 3 Data'", errorMessage, ndcCharBuffer));
 
             stateObject.withAdditionalData(new CardReaderWriterAdditionalData(track1Data, track2Data, track3Data));
             checkNoDataRemains(ndcCharBuffer);
@@ -53,7 +58,7 @@ public class CardReaderWriterAdditionalDataAppender implements ConfigurableNdcCo
         if (ndcCharBuffer.hasRemaining()) {
             final String errorMessage = String.format("unexpected data '%s' at position %d", ndcCharBuffer.subBuffer(),
                     ndcCharBuffer.position());
-            throw NdcMessageParseException.withMessage(UnsolicitedStatusMessage.COMMAND_NAME, "'Additional Data'", errorMessage, ndcCharBuffer);
+            throw withMessage(UnsolicitedStatusMessage.COMMAND_NAME, "'Additional Data'", errorMessage, ndcCharBuffer);
         }
     }
 }

--- a/jndc/src/main/java/io/github/jokoroukwu/jndc/terminal/statusmessage/unsolicited/UnsolicitedStatusMessageBuilder.java
+++ b/jndc/src/main/java/io/github/jokoroukwu/jndc/terminal/statusmessage/unsolicited/UnsolicitedStatusMessageBuilder.java
@@ -16,6 +16,14 @@ public final class UnsolicitedStatusMessageBuilder<T extends UnsolicitedStatusIn
         return this;
     }
 
+    public Luno getLuno() {
+        return luno;
+    }
+
+    public T getStatusInformation() {
+        return statusInformation;
+    }
+
     public UnsolicitedStatusMessage<T> build() {
         return new UnsolicitedStatusMessage<>(luno, statusInformation);
     }

--- a/jndc/src/main/java/io/github/jokoroukwu/jndc/terminal/statusmessage/unsolicited/timeofdayclock/ClockDeviceStatus.java
+++ b/jndc/src/main/java/io/github/jokoroukwu/jndc/terminal/statusmessage/unsolicited/timeofdayclock/ClockDeviceStatus.java
@@ -1,0 +1,45 @@
+package io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.timeofdayclock;
+
+import io.github.jokoroukwu.jndc.NdcComponent;
+import io.github.jokoroukwu.jndc.util.optional.DescriptiveOptional;
+
+public enum ClockDeviceStatus implements NdcComponent {
+    RESET('1'),
+    STOPPED('2');
+
+    private final char value;
+    private final String displayedName;
+
+    ClockDeviceStatus(char value) {
+        this.value = value;
+        displayedName = String.format("%s ('%c')", name(), value);
+    }
+
+    public static DescriptiveOptional<ClockDeviceStatus> forValue(char value) {
+        if (value == '1') {
+            return DescriptiveOptional.of(RESET);
+        }
+        if (value == '2') {
+            return DescriptiveOptional.of(STOPPED);
+        }
+        return DescriptiveOptional.empty(() -> String.format("value '%c' is not a valid Clock Device Status", value));
+    }
+
+    public static DescriptiveOptional<ClockDeviceStatus> forValue(int value) {
+        return forValue((char) value);
+    }
+
+    public char getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return displayedName;
+    }
+
+    @Override
+    public String toNdcString() {
+        return Character.toString(value);
+    }
+}

--- a/jndc/src/main/java/io/github/jokoroukwu/jndc/terminal/statusmessage/unsolicited/timeofdayclock/TimeOfDayClockFailure.java
+++ b/jndc/src/main/java/io/github/jokoroukwu/jndc/terminal/statusmessage/unsolicited/timeofdayclock/TimeOfDayClockFailure.java
@@ -1,0 +1,86 @@
+package io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.timeofdayclock;
+
+import io.github.jokoroukwu.jndc.terminal.TerminalMessageClass;
+import io.github.jokoroukwu.jndc.terminal.TerminalMessageSubClass;
+import io.github.jokoroukwu.jndc.terminal.dig.Dig;
+import io.github.jokoroukwu.jndc.terminal.statusmessage.devicefault.DeviceFault;
+import io.github.jokoroukwu.jndc.terminal.statusmessage.devicefault.ErrorSeverity;
+import io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.UnsolicitedStatusInformation;
+import io.github.jokoroukwu.jndc.util.NdcStringBuilder;
+import io.github.jokoroukwu.jndc.util.ObjectUtils;
+
+import java.util.Objects;
+import java.util.StringJoiner;
+
+public class TimeOfDayClockFailure implements DeviceFault, UnsolicitedStatusInformation {
+    public static final String COMMAND_NAME = TerminalMessageClass.UNSOLICITED + ": "
+            + TerminalMessageSubClass.STATUS_MESSAGE
+            + ": "
+            + Dig.TIME_OF_DAY_CLOCK;
+
+    private final ClockDeviceStatus deviceStatus;
+    private final ErrorSeverity errorSeverity;
+
+    public TimeOfDayClockFailure(ClockDeviceStatus deviceStatus, ErrorSeverity errorSeverity) {
+        this.deviceStatus = ObjectUtils.validateNotNull(deviceStatus, "'Device Status'");
+        this.errorSeverity = validateErrorSeverity(errorSeverity);
+    }
+
+    TimeOfDayClockFailure(ClockDeviceStatus deviceStatus, ErrorSeverity errorSeverity, Void unused) {
+        this.deviceStatus = deviceStatus;
+        this.errorSeverity = errorSeverity;
+    }
+
+    public ClockDeviceStatus getDeviceStatus() {
+        return deviceStatus;
+    }
+
+    public ErrorSeverity getErrorSeverity() {
+        return errorSeverity;
+    }
+
+    @Override
+    public String toNdcString() {
+        return new NdcStringBuilder(3)
+                .appendComponent(Dig.TIME_OF_DAY_CLOCK)
+                .appendComponent(deviceStatus)
+                .appendComponent(errorSeverity)
+                .toString();
+    }
+
+    @Override
+    public Dig getDig() {
+        return Dig.TIME_OF_DAY_CLOCK;
+    }
+
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", TimeOfDayClockFailure.class.getSimpleName() + ": {", "}")
+                .add("deviceStatus: " + deviceStatus)
+                .add("errorSeverity: " + errorSeverity)
+                .toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TimeOfDayClockFailure that = (TimeOfDayClockFailure) o;
+        return deviceStatus == that.deviceStatus && errorSeverity == that.errorSeverity;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(deviceStatus, errorSeverity);
+    }
+
+    private ErrorSeverity validateErrorSeverity(ErrorSeverity errorSeverity) {
+        if (ErrorSeverity.WARNING == errorSeverity || ErrorSeverity.FATAL == errorSeverity) {
+            return errorSeverity;
+        }
+        final String errorMessage = String.format("'Error Severity' should be %s or %s but was: %s", ErrorSeverity.WARNING,
+                ErrorSeverity.FATAL, errorSeverity);
+        throw new IllegalArgumentException(errorMessage);
+    }
+}

--- a/jndc/src/main/java/io/github/jokoroukwu/jndc/terminal/statusmessage/unsolicited/timeofdayclock/TimeOfDayClockFailureAppender.java
+++ b/jndc/src/main/java/io/github/jokoroukwu/jndc/terminal/statusmessage/unsolicited/timeofdayclock/TimeOfDayClockFailureAppender.java
@@ -1,0 +1,50 @@
+package io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.timeofdayclock;
+
+import io.github.jokoroukwu.jndc.NdcCharBuffer;
+import io.github.jokoroukwu.jndc.terminal.ConfigurableNdcComponentAppender;
+import io.github.jokoroukwu.jndc.terminal.DeviceConfiguration;
+import io.github.jokoroukwu.jndc.terminal.statusmessage.devicefault.ErrorSeverity;
+import io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.UnsolicitedStatusInformation;
+import io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.UnsolicitedStatusMessage;
+import io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.UnsolicitedStatusMessageBuilder;
+import io.github.jokoroukwu.jndc.util.ObjectUtils;
+
+import static io.github.jokoroukwu.jndc.exception.NdcMessageParseException.withMessage;
+import static io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.timeofdayclock.TimeOfDayClockFailure.COMMAND_NAME;
+
+public class TimeOfDayClockFailureAppender implements ConfigurableNdcComponentAppender<UnsolicitedStatusMessageBuilder<UnsolicitedStatusInformation>> {
+    private final TimeOfDayClockFailureMessageListener messageListener;
+
+    public TimeOfDayClockFailureAppender(TimeOfDayClockFailureMessageListener messageListener) {
+        this.messageListener = ObjectUtils.validateNotNull(messageListener, "messageListener");
+    }
+
+    @Override
+    public void appendComponent(NdcCharBuffer ndcCharBuffer,
+                                UnsolicitedStatusMessageBuilder<UnsolicitedStatusInformation> stateObject,
+                                DeviceConfiguration deviceConfiguration) {
+
+        final ClockDeviceStatus clockDeviceStatus = readDeviceStatus(ndcCharBuffer);
+        final ErrorSeverity errorSeverity = readErrorSeverity(ndcCharBuffer);
+
+        final UnsolicitedStatusMessageBuilder<? extends UnsolicitedStatusInformation> builder = stateObject
+                .withStatusInformation(new TimeOfDayClockFailure(clockDeviceStatus, errorSeverity, null));
+
+        @SuppressWarnings("unchecked") final UnsolicitedStatusMessage<TimeOfDayClockFailure> timeOfDayClockFailureMessage
+                = (UnsolicitedStatusMessage<TimeOfDayClockFailure>) builder.build();
+
+        messageListener.onTimeOfDayClockFailureMessage(timeOfDayClockFailureMessage);
+    }
+
+    private ClockDeviceStatus readDeviceStatus(NdcCharBuffer ndcCharBuffer) {
+        return ndcCharBuffer.tryReadNextChar()
+                .flatMapToObject(ClockDeviceStatus::forValue)
+                .getOrThrow(errorMessage -> withMessage(COMMAND_NAME, "'Device Status'", errorMessage, ndcCharBuffer));
+    }
+
+    private ErrorSeverity readErrorSeverity(NdcCharBuffer ndcCharBuffer) {
+        return ndcCharBuffer.tryReadNextChar()
+                .flatMapToObject(ErrorSeverity::forValue)
+                .getOrThrow(errorMessage -> withMessage(COMMAND_NAME, "'Error Severity'", errorMessage, ndcCharBuffer));
+    }
+}

--- a/jndc/src/main/java/io/github/jokoroukwu/jndc/terminal/statusmessage/unsolicited/timeofdayclock/TimeOfDayClockFailureMessageListener.java
+++ b/jndc/src/main/java/io/github/jokoroukwu/jndc/terminal/statusmessage/unsolicited/timeofdayclock/TimeOfDayClockFailureMessageListener.java
@@ -1,0 +1,8 @@
+package io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.timeofdayclock;
+
+import io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.UnsolicitedStatusMessage;
+
+public interface TimeOfDayClockFailureMessageListener {
+
+    void onTimeOfDayClockFailureMessage(UnsolicitedStatusMessage<TimeOfDayClockFailure> timeOfDayClockFailureMessage);
+}

--- a/jndc/src/test/java/io/github/jokoroukwu/jndc/terminal/statusmessage/unsolicited/UnsolicitedMessageAppenderTest.java
+++ b/jndc/src/test/java/io/github/jokoroukwu/jndc/terminal/statusmessage/unsolicited/UnsolicitedMessageAppenderTest.java
@@ -1,0 +1,19 @@
+package io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited;
+
+import io.github.jokoroukwu.jndc.Luno;
+import io.github.jokoroukwu.jndc.terminal.DeviceConfiguration;
+import org.testng.annotations.BeforeClass;
+
+import static org.mockito.Mockito.mock;
+
+public abstract class UnsolicitedMessageAppenderTest {
+    protected DeviceConfiguration deviceConfigurationMock;
+    protected UnsolicitedStatusMessageBuilder<UnsolicitedStatusInformation> messageBuilder;
+
+    @BeforeClass
+    public void baseSetUp() {
+        deviceConfigurationMock = mock(DeviceConfiguration.class);
+        messageBuilder = new UnsolicitedStatusMessageBuilder<>()
+                .withLuno(Luno.DEFAULT);
+    }
+}

--- a/jndc/src/test/java/io/github/jokoroukwu/jndc/terminal/statusmessage/unsolicited/timeofdayclock/TimeOfDayClockAppenderTest.java
+++ b/jndc/src/test/java/io/github/jokoroukwu/jndc/terminal/statusmessage/unsolicited/timeofdayclock/TimeOfDayClockAppenderTest.java
@@ -1,0 +1,38 @@
+package io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.timeofdayclock;
+
+import io.github.jokoroukwu.jndc.Luno;
+import io.github.jokoroukwu.jndc.NdcCharBuffer;
+import io.github.jokoroukwu.jndc.terminal.statusmessage.devicefault.ErrorSeverity;
+import io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.UnsolicitedMessageAppenderTest;
+import io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.UnsolicitedStatusMessage;
+import io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.UnsolicitedStatusMessageBuilder;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.*;
+
+public class TimeOfDayClockAppenderTest extends UnsolicitedMessageAppenderTest {
+    private TimeOfDayClockFailureAppender appender;
+    private TimeOfDayClockFailureMessageListener messageListenerMock;
+
+    @BeforeClass
+    public void setUp() {
+        messageListenerMock = mock(TimeOfDayClockFailureMessageListener.class);
+        appender = new TimeOfDayClockFailureAppender(messageListenerMock);
+    }
+
+    @Test
+    public void should_call_message_listener_with_expected_arg() {
+        final NdcCharBuffer buffer = NdcCharBuffer.wrap(ClockDeviceStatus.RESET.toNdcString() + ErrorSeverity.FATAL.toNdcString());
+        appender.appendComponent(buffer, messageBuilder, deviceConfigurationMock);
+
+        final UnsolicitedStatusMessage<TimeOfDayClockFailure> expectedMessage = new UnsolicitedStatusMessageBuilder<TimeOfDayClockFailure>()
+                .withLuno(Luno.DEFAULT)
+                .withStatusInformation(new TimeOfDayClockFailure(ClockDeviceStatus.RESET, ErrorSeverity.FATAL))
+                .build();
+
+        verify(messageListenerMock, times(1))
+                .onTimeOfDayClockFailureMessage(expectedMessage);
+        verifyNoInteractions(deviceConfigurationMock);
+    }
+}

--- a/jndc/src/test/java/io/github/jokoroukwu/jndc/terminal/statusmessage/unsolicited/timeofdayclock/TimeOfDayClockFailureTest.java
+++ b/jndc/src/test/java/io/github/jokoroukwu/jndc/terminal/statusmessage/unsolicited/timeofdayclock/TimeOfDayClockFailureTest.java
@@ -1,0 +1,37 @@
+package io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.timeofdayclock;
+
+import io.github.jokoroukwu.jndc.terminal.dig.Dig;
+import io.github.jokoroukwu.jndc.terminal.statusmessage.devicefault.ErrorSeverity;
+import org.assertj.core.api.Assertions;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.EnumSet;
+import java.util.Iterator;
+
+public class TimeOfDayClockFailureTest {
+
+    @DataProvider
+    public Iterator<Object[]> invalidErrorSeverityProvider() {
+        return EnumSet.complementOf(EnumSet.of(ErrorSeverity.FATAL, ErrorSeverity.WARNING))
+                .stream()
+                .map(value -> new Object[]{value})
+                .iterator();
+    }
+
+    @Test(dataProvider = "invalidErrorSeverityProvider")
+    public void should_throw_expected_exception_on_invalid_error_severity(ErrorSeverity invalidErrorSeverity) {
+        Assertions.assertThatThrownBy(() -> new TimeOfDayClockFailure(ClockDeviceStatus.RESET, invalidErrorSeverity))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Error Severity");
+    }
+
+    @Test
+    public void should_return_expected_ndc_string() {
+        final String actualNdcString = new TimeOfDayClockFailure(ClockDeviceStatus.STOPPED, ErrorSeverity.FATAL).toNdcString();
+        final String expectedNdcString = Dig.TIME_OF_DAY_CLOCK.getValue() + "2" + ErrorSeverity.FATAL.getValue();
+
+        Assertions.assertThat(actualNdcString)
+                .isEqualTo(expectedNdcString);
+    }
+}

--- a/jndc/src/test/java/io/github/jokoroukwu/jndc/terminal/statusmessage/unsolicited/timeofdayclock/TimeOfDayClockIntegrationTest.java
+++ b/jndc/src/test/java/io/github/jokoroukwu/jndc/terminal/statusmessage/unsolicited/timeofdayclock/TimeOfDayClockIntegrationTest.java
@@ -1,0 +1,39 @@
+package io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.timeofdayclock;
+
+import io.github.jokoroukwu.jndc.NdcCharBuffer;
+import io.github.jokoroukwu.jndc.terminal.*;
+import io.github.jokoroukwu.jndc.terminal.meta.TerminalMessageMeta;
+import io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.UnsolicitedStatusMessage;
+import org.assertj.core.api.Assertions;
+import org.testng.annotations.Test;
+
+import java.util.Set;
+
+public class TimeOfDayClockIntegrationTest implements TerminalMessageListener, DeviceConfigurationSupplier<TerminalMessageMeta> {
+    private final TerminalMessagePreProcessor messagePreProcessor = new TerminalMessagePreProcessor(this, this);
+    private final String rawMessage = "12\u001C324123456\u001C\u001CA24";
+    private UnsolicitedStatusMessage<TimeOfDayClockFailure> message;
+
+    @Override
+    public void onTimeOfDayClockFailureMessage(UnsolicitedStatusMessage<TimeOfDayClockFailure> message) {
+        this.message = message;
+    }
+
+    @Override
+    public DeviceConfiguration getConfiguration(TerminalMessageMeta meta) {
+        return new DeviceConfigurationBase(true, Set.of(), ConfigurationOptions.EMPTY);
+    }
+
+    @Test
+    public void should_read_whole_message_normally() {
+        final NdcCharBuffer buffer = NdcCharBuffer.wrap(rawMessage);
+        Assertions.assertThatCode(() -> messagePreProcessor.processMessage(buffer))
+                .doesNotThrowAnyException();
+    }
+
+    @Test(dependsOnMethods = "should_read_whole_message_normally")
+    public void encoded_message_should_be_equal_to_original() {
+        Assertions.assertThat(message.toNdcString())
+                .isEqualTo(rawMessage);
+    }
+}


### PR DESCRIPTION
 * Added 'Time of Day Clock Failure message' data objects and appender to io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.timeofdayclock
 * TerminalMessageListener now implements TimeOfDayClockFailureMessageListener
 * Added corresponding tests