### PR TITLE
Add unsolicited 'Power Failure' message support.

### DIFF
--- a/examples/src/main/java/io/github/jokoroukwu/examples/central/LoggingCentralMessageListener.java
+++ b/examples/src/main/java/io/github/jokoroukwu/examples/central/LoggingCentralMessageListener.java
@@ -21,7 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * This listener was created for just to demonstrate
+ * This listener implementation is just a demonstration of
  * how central messages are consumed.
  */
 public class LoggingCentralMessageListener implements CentralMessageListener {

--- a/examples/src/main/java/io/github/jokoroukwu/examples/terminal/LoggingTerminalMessageListener.java
+++ b/examples/src/main/java/io/github/jokoroukwu/examples/terminal/LoggingTerminalMessageListener.java
@@ -13,14 +13,15 @@ import io.github.jokoroukwu.jndc.terminal.statusmessage.readyb.ReadyBStatus;
 import io.github.jokoroukwu.jndc.terminal.statusmessage.solicited.terminalstate.supplycountersbasic.SupplyCountersBasic;
 import io.github.jokoroukwu.jndc.terminal.statusmessage.solicited.terminalstate.supplycountersextended.SupplyCountersExtended;
 import io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.UnsolicitedStatusMessage;
-import io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.timeofdayclock.TimeOfDayClockFailure;
+import io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.powerfailure.PowerFailure;
+import io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.timeofdayclock.TimeOfDayClock;
 import io.github.jokoroukwu.jndc.terminal.transactionrequestmessage.TransactionRequestMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
 /**
- * This listener was created for just to demonstrate
+ * This listener implementation is just a demonstration of
  * how central messages are consumed.
  */
 public class LoggingTerminalMessageListener implements TerminalMessageListener {
@@ -92,7 +93,12 @@ public class LoggingTerminalMessageListener implements TerminalMessageListener {
     }
 
     @Override
-    public void onTimeOfDayClockFailureMessage(UnsolicitedStatusMessage<TimeOfDayClockFailure> message) {
+    public void onTimeOfDayClockStatusMessage(UnsolicitedStatusMessage<TimeOfDayClock> message) {
         LOGGER.info("Time of Day Clock Failure Unsolicited Status message received: {}", message);
+    }
+
+    @Override
+    public void onPowerFailureMessage(UnsolicitedStatusMessage<PowerFailure> message) {
+        LOGGER.info("Power Failure Unsolicited Status message received: {}", message);
     }
 }

--- a/jndc/src/main/java/io/github/jokoroukwu/jndc/terminal/TerminalMessageListener.java
+++ b/jndc/src/main/java/io/github/jokoroukwu/jndc/terminal/TerminalMessageListener.java
@@ -23,7 +23,9 @@ import io.github.jokoroukwu.jndc.terminal.statusmessage.solicited.terminalstate.
 import io.github.jokoroukwu.jndc.terminal.statusmessage.solicited.terminalstate.supplycountersextended.SupplyCountersExtended;
 import io.github.jokoroukwu.jndc.terminal.statusmessage.solicited.terminalstate.supplycountersextended.SupplyCountersExtendedMessageListener;
 import io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.UnsolicitedStatusMessage;
-import io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.timeofdayclock.TimeOfDayClockFailure;
+import io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.powerfailure.PowerFailure;
+import io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.powerfailure.PowerFailureMessageListener;
+import io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.timeofdayclock.TimeOfDayClock;
 import io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.timeofdayclock.TimeOfDayClockFailureMessageListener;
 import io.github.jokoroukwu.jndc.terminal.transactionrequestmessage.TransactionRequestMessage;
 import io.github.jokoroukwu.jndc.terminal.transactionrequestmessage.TransactionRequestMessageListener;
@@ -32,7 +34,8 @@ public interface TerminalMessageListener extends TransactionRequestMessageListen
         UnsolicitedCardReaderWriterFaultMessageListener, EncryptorInitialisationDataMessageListener,
         SupplyCountersBasicMessageListener, SupplyCountersExtendedMessageListener, ReadyBStatusMessageListener,
         CommandRejectStatusMessageListener, ReadyStatusMessageListener, GenericSolicitedStatusMessageListener,
-        SolicitedGenericDeviceFaultMessageListener, SolicitedCardReaderWriterFaultMessageListener, TimeOfDayClockFailureMessageListener {
+        SolicitedGenericDeviceFaultMessageListener, SolicitedCardReaderWriterFaultMessageListener, TimeOfDayClockFailureMessageListener,
+        PowerFailureMessageListener {
 
     @Override
     default void onTransactionRequestMessage(TransactionRequestMessage message) {
@@ -99,7 +102,12 @@ public interface TerminalMessageListener extends TransactionRequestMessageListen
     }
 
     @Override
-    default void onTimeOfDayClockFailureMessage(UnsolicitedStatusMessage<TimeOfDayClockFailure> message) {
+    default void onTimeOfDayClockStatusMessage(UnsolicitedStatusMessage<TimeOfDayClock> message) {
+
+    }
+
+    @Override
+    default void onPowerFailureMessage(UnsolicitedStatusMessage<PowerFailure> message) {
 
     }
 }

--- a/jndc/src/main/java/io/github/jokoroukwu/jndc/terminal/statusmessage/UnsolicitedStatusMessageAppender.java
+++ b/jndc/src/main/java/io/github/jokoroukwu/jndc/terminal/statusmessage/UnsolicitedStatusMessageAppender.java
@@ -14,7 +14,8 @@ import io.github.jokoroukwu.jndc.terminal.statusmessage.devicefault.genericfault
 import io.github.jokoroukwu.jndc.terminal.statusmessage.devicefault.genericfault.UnsolicitedGenericDeviceFaultMessageListener;
 import io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.UnsolicitedStatusInformation;
 import io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.UnsolicitedStatusMessageBuilder;
-import io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.timeofdayclock.TimeOfDayClockFailureAppender;
+import io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.powerfailure.PowerFailureMessageAppender;
+import io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.timeofdayclock.TimeOfDayClockMessageAppender;
 import io.github.jokoroukwu.jndc.util.ObjectUtils;
 
 import java.util.EnumMap;
@@ -45,7 +46,8 @@ public class UnsolicitedStatusMessageAppender implements NdcComponentAppender<Te
         final Map<Dig, ConfigurableNdcComponentAppender<UnsolicitedStatusMessageBuilder<UnsolicitedStatusInformation>>> appenderMap
                 = new EnumMap<>(Dig.class);
         appenderMap.put(Dig.MAGNETIC_CARD_READER_WRITER, new UnsolicitedCardReaderWriterFaultAppender(messageListener));
-        appenderMap.put(Dig.TIME_OF_DAY_CLOCK, new TimeOfDayClockFailureAppender(messageListener));
+        appenderMap.put(Dig.TIME_OF_DAY_CLOCK, new TimeOfDayClockMessageAppender(messageListener));
+        appenderMap.put(Dig.COMMUNICATIONS, new PowerFailureMessageAppender(messageListener));
         putGenericAppenders(appenderMap, messageListener);
 
         appenderFactory = new ConfigurableNdcComponentAppenderFactoryBase<>(appenderMap);
@@ -55,7 +57,13 @@ public class UnsolicitedStatusMessageAppender implements NdcComponentAppender<Te
             ConfigurableNdcComponentAppender<UnsolicitedStatusMessageBuilder<UnsolicitedStatusInformation>>> appenderMap,
                                             UnsolicitedGenericDeviceFaultMessageListener messageListener) {
 
-        for (Dig dig : EnumSet.complementOf(EnumSet.of(Dig.TIME_OF_DAY_CLOCK, Dig.MAGNETIC_CARD_READER_WRITER))) {
+        final EnumSet<Dig> digsWithImplementations = EnumSet.of(
+                Dig.TIME_OF_DAY_CLOCK,
+                Dig.MAGNETIC_CARD_READER_WRITER,
+                Dig.COMMUNICATIONS
+        );
+
+        for (Dig dig : EnumSet.complementOf(digsWithImplementations)) {
             appenderMap.put(dig, new UnsolicitedGenericDeviceFaultAppender(dig, messageListener));
         }
     }

--- a/jndc/src/main/java/io/github/jokoroukwu/jndc/terminal/statusmessage/devicefault/DeviceStatusInformation.java
+++ b/jndc/src/main/java/io/github/jokoroukwu/jndc/terminal/statusmessage/devicefault/DeviceStatusInformation.java
@@ -6,7 +6,7 @@ import io.github.jokoroukwu.jndc.terminal.TerminalMessageSubClass;
 import io.github.jokoroukwu.jndc.terminal.dig.Dig;
 import io.github.jokoroukwu.jndc.terminal.statusmessage.StatusDescriptor;
 
-public interface DeviceFault extends NdcComponent {
+public interface DeviceStatusInformation extends NdcComponent {
     String COMMAND_NAME = TerminalMessageClass.SOLICITED + ": " + TerminalMessageSubClass.STATUS_MESSAGE + ": "
             + StatusDescriptor.DEVICE_FAULT;
 

--- a/jndc/src/main/java/io/github/jokoroukwu/jndc/terminal/statusmessage/devicefault/SolicitedDeviceFaultAppender.java
+++ b/jndc/src/main/java/io/github/jokoroukwu/jndc/terminal/statusmessage/devicefault/SolicitedDeviceFaultAppender.java
@@ -51,19 +51,19 @@ public class SolicitedDeviceFaultAppender
                                 DeviceConfiguration deviceConfiguration) {
 
         ndcCharBuffer.trySkipFieldSeparator()
-                .ifPresent(errorMessage -> NdcMessageParseException.onNoFieldSeparator(DeviceFault.COMMAND_NAME,
+                .ifPresent(errorMessage -> NdcMessageParseException.onNoFieldSeparator(DeviceStatusInformation.COMMAND_NAME,
                         "Status Information", errorMessage, ndcCharBuffer));
 
         final Dig dig = readDig(ndcCharBuffer);
         appenderFactory.getAppender(dig)
                 .ifPresentOrElse(appender -> appender.appendComponent(ndcCharBuffer, stateObject, deviceConfiguration),
-                        () -> onConfigError(DeviceFault.COMMAND_NAME, "no appender configured for DIG " + dig));
+                        () -> onConfigError(DeviceStatusInformation.COMMAND_NAME, "no appender configured for DIG " + dig));
     }
 
     private Dig readDig(NdcCharBuffer ndcCharBuffer) {
         return ndcCharBuffer.tryReadNextChar()
                 .flatMapToObject(Dig::forValue)
-                .getOrThrow(errorMessage -> NdcMessageParseException.withMessage(DeviceFault.COMMAND_NAME, "Device Identifier Graphic (DIG)",
+                .getOrThrow(errorMessage -> NdcMessageParseException.withMessage(DeviceStatusInformation.COMMAND_NAME, "Device Identifier Graphic (DIG)",
                         errorMessage, ndcCharBuffer));
     }
 }

--- a/jndc/src/main/java/io/github/jokoroukwu/jndc/terminal/statusmessage/devicefault/cardreader/CardReaderWriterFault.java
+++ b/jndc/src/main/java/io/github/jokoroukwu/jndc/terminal/statusmessage/devicefault/cardreader/CardReaderWriterFault.java
@@ -3,7 +3,7 @@ package io.github.jokoroukwu.jndc.terminal.statusmessage.devicefault.cardreader;
 import io.github.jokoroukwu.jndc.terminal.completiondata.CompletionData;
 import io.github.jokoroukwu.jndc.terminal.dig.Dig;
 import io.github.jokoroukwu.jndc.terminal.statusmessage.SolicitedStatusInformation;
-import io.github.jokoroukwu.jndc.terminal.statusmessage.devicefault.DeviceFault;
+import io.github.jokoroukwu.jndc.terminal.statusmessage.devicefault.DeviceStatusInformation;
 import io.github.jokoroukwu.jndc.terminal.statusmessage.devicefault.ErrorSeverity;
 import io.github.jokoroukwu.jndc.terminal.statusmessage.devicefault.SuppliesStatus;
 import io.github.jokoroukwu.jndc.terminal.statusmessage.devicefault.diagnosticstatus.DiagnosticStatus;
@@ -13,7 +13,7 @@ import io.github.jokoroukwu.jndc.util.NdcStringBuilder;
 
 import java.util.*;
 
-public class CardReaderWriterFault implements DeviceFault, SolicitedStatusInformation, UnsolicitedStatusInformation {
+public class CardReaderWriterFault implements DeviceStatusInformation, SolicitedStatusInformation, UnsolicitedStatusInformation {
     private final TransactionDeviceStatus transactionDeviceStatus;
     private final List<ErrorSeverity> errorSeverities;
     private final DiagnosticStatus diagnosticStatus;

--- a/jndc/src/main/java/io/github/jokoroukwu/jndc/terminal/statusmessage/devicefault/diagnosticstatus/DiagnosticStatusReader.java
+++ b/jndc/src/main/java/io/github/jokoroukwu/jndc/terminal/statusmessage/devicefault/diagnosticstatus/DiagnosticStatusReader.java
@@ -3,8 +3,8 @@ package io.github.jokoroukwu.jndc.terminal.statusmessage.devicefault.diagnostics
 import io.github.jokoroukwu.jndc.NdcCharBuffer;
 import io.github.jokoroukwu.jndc.exception.NdcMessageParseException;
 import io.github.jokoroukwu.jndc.terminal.DeviceConfiguration;
-import io.github.jokoroukwu.jndc.terminal.statusmessage.devicefault.DeviceFault;
 import io.github.jokoroukwu.jndc.terminal.statusmessage.devicefault.DeviceFaultFieldReader;
+import io.github.jokoroukwu.jndc.terminal.statusmessage.devicefault.DeviceStatusInformation;
 import io.github.jokoroukwu.jndc.util.Integers;
 import io.github.jokoroukwu.jndc.util.text.Strings;
 
@@ -19,7 +19,7 @@ public class DiagnosticStatusReader extends DeviceFaultFieldReader<Optional<Diag
         //  at least the field separator should be present
         ndcCharBuffer.trySkipFieldSeparator()
                 .ifPresent(errorMessage
-                        -> NdcMessageParseException.onNoFieldSeparator(DeviceFault.COMMAND_NAME, "Diagnostic Status", errorMessage, ndcCharBuffer));
+                        -> NdcMessageParseException.onNoFieldSeparator(DeviceStatusInformation.COMMAND_NAME, "Diagnostic Status", errorMessage, ndcCharBuffer));
         if (!ndcCharBuffer.hasFieldDataRemaining()) {
             return Optional.empty();
         }
@@ -28,7 +28,7 @@ public class DiagnosticStatusReader extends DeviceFaultFieldReader<Optional<Diag
 
     private DiagnosticStatus readDiagnosticStatus(NdcCharBuffer ndcCharBuffer) {
         final int mainErrorStatus = ndcCharBuffer.tryReadInt(2)
-                .getOrThrow(errorMessage -> NdcMessageParseException.withMessage(DeviceFault.COMMAND_NAME, "Diagnostic Status: M‐Status",
+                .getOrThrow(errorMessage -> NdcMessageParseException.withMessage(DeviceStatusInformation.COMMAND_NAME, "Diagnostic Status: M‐Status",
                         errorMessage, ndcCharBuffer));
 
         final StringBuilder builder = new StringBuilder();
@@ -42,11 +42,11 @@ public class DiagnosticStatusReader extends DeviceFaultFieldReader<Optional<Diag
 
     private void validateDiagnosticStatus(String value, NdcCharBuffer ndcCharBuffer) {
         if (!Integers.isEven(value.length())) {
-            throw NdcMessageParseException.withMessage(DeviceFault.COMMAND_NAME, "Diagnostic Status: Diagnostic Information",
+            throw NdcMessageParseException.withMessage(DeviceStatusInformation.COMMAND_NAME, "Diagnostic Status: Diagnostic Information",
                     "value length should be even but was " + value.length(), ndcCharBuffer);
         }
         if (!Strings.isHex(value)) {
-            throw NdcMessageParseException.withMessage(DeviceFault.COMMAND_NAME, "Diagnostic Status: Diagnostic Information",
+            throw NdcMessageParseException.withMessage(DeviceStatusInformation.COMMAND_NAME, "Diagnostic Status: Diagnostic Information",
                     String.format("value should be hexadecimal but was '%s'", value), ndcCharBuffer);
         }
     }

--- a/jndc/src/main/java/io/github/jokoroukwu/jndc/terminal/statusmessage/devicefault/genericfault/GenericSuppliesStatusAppender.java
+++ b/jndc/src/main/java/io/github/jokoroukwu/jndc/terminal/statusmessage/devicefault/genericfault/GenericSuppliesStatusAppender.java
@@ -4,8 +4,8 @@ import io.github.jokoroukwu.jndc.NdcCharBuffer;
 import io.github.jokoroukwu.jndc.exception.NdcMessageParseException;
 import io.github.jokoroukwu.jndc.terminal.ConfigurableNdcComponentAppender;
 import io.github.jokoroukwu.jndc.terminal.DeviceConfiguration;
-import io.github.jokoroukwu.jndc.terminal.statusmessage.devicefault.DeviceFault;
 import io.github.jokoroukwu.jndc.terminal.statusmessage.devicefault.DeviceFaultFieldAppender;
+import io.github.jokoroukwu.jndc.terminal.statusmessage.devicefault.DeviceStatusInformation;
 import io.github.jokoroukwu.jndc.terminal.statusmessage.devicefault.SuppliesStatus;
 
 import java.util.ArrayList;
@@ -27,7 +27,7 @@ public class GenericSuppliesStatusAppender extends DeviceFaultFieldAppender<Gene
         if (ndcCharBuffer.hasRemaining() && !hasFollowingMac(deviceConfiguration, ndcCharBuffer)) {
             //  at least the field separator should be present
             ndcCharBuffer.trySkipFieldSeparator()
-                    .ifPresent(errorMessage -> NdcMessageParseException.onNoFieldSeparator(DeviceFault.COMMAND_NAME, "Supplies Status",
+                    .ifPresent(errorMessage -> NdcMessageParseException.onNoFieldSeparator(DeviceStatusInformation.COMMAND_NAME, "Supplies Status",
                             errorMessage, ndcCharBuffer));
             final List<SuppliesStatus> suppliesStatuses = readSuppliesStatuses(ndcCharBuffer);
             stateObject.withSuppliesStatuses(suppliesStatuses);
@@ -45,7 +45,7 @@ public class GenericSuppliesStatusAppender extends DeviceFaultFieldAppender<Gene
             ndcCharBuffer.tryReadNextChar()
                     .flatMapToObject(SuppliesStatus::forValue)
                     .resolve(suppliesStatuses::add, errorMessage
-                            -> NdcMessageParseException.onFieldParseError(DeviceFault.COMMAND_NAME, "Supplies Status", errorMessage, ndcCharBuffer));
+                            -> NdcMessageParseException.onFieldParseError(DeviceStatusInformation.COMMAND_NAME, "Supplies Status", errorMessage, ndcCharBuffer));
         } while (ndcCharBuffer.hasFieldDataRemaining());
 
         suppliesStatuses.trimToSize();

--- a/jndc/src/main/java/io/github/jokoroukwu/jndc/terminal/statusmessage/unsolicited/powerfailure/PowerFailure.java
+++ b/jndc/src/main/java/io/github/jokoroukwu/jndc/terminal/statusmessage/unsolicited/powerfailure/PowerFailure.java
@@ -1,17 +1,28 @@
-package io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited;
+package io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.powerfailure;
 
+import io.github.jokoroukwu.jndc.terminal.TerminalMessageClass;
+import io.github.jokoroukwu.jndc.terminal.TerminalMessageSubClass;
 import io.github.jokoroukwu.jndc.terminal.dig.Dig;
-import io.github.jokoroukwu.jndc.terminal.statusmessage.devicefault.DeviceFault;
+import io.github.jokoroukwu.jndc.terminal.statusmessage.devicefault.DeviceStatusInformation;
+import io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.UnsolicitedStatusInformation;
 import io.github.jokoroukwu.jndc.util.Integers;
 
 import java.util.Objects;
 import java.util.StringJoiner;
 
-public final class PowerFailure implements DeviceFault, UnsolicitedStatusInformation {
+public final class PowerFailure implements DeviceStatusInformation, UnsolicitedStatusInformation {
+    public static final java.lang.String COMMAND_NAME = TerminalMessageClass.UNSOLICITED
+            + ": " + TerminalMessageSubClass.STATUS_MESSAGE
+            + ": " + Dig.COMMUNICATIONS;
+
     private final int configurationId;
 
     public PowerFailure(int configurationId) {
         this.configurationId = Integers.validateRange(configurationId, 0, 9999, "'Configuration ID'");
+    }
+
+    PowerFailure(int configurationId, Void unused) {
+        this.configurationId = configurationId;
     }
 
     public int getConfigurationId() {
@@ -24,12 +35,12 @@ public final class PowerFailure implements DeviceFault, UnsolicitedStatusInforma
     }
 
     @Override
-    public String toNdcString() {
+    public java.lang.String toNdcString() {
         return Dig.COMMUNICATIONS.toNdcString() + Integers.toZeroPaddedString(configurationId, 4);
     }
 
     @Override
-    public String toString() {
+    public java.lang.String toString() {
         return new StringJoiner(", ", PowerFailure.class.getSimpleName() + ": {", "}")
                 .add("dig: " + Dig.COMMUNICATIONS)
                 .add("configurationId: " + configurationId)

--- a/jndc/src/main/java/io/github/jokoroukwu/jndc/terminal/statusmessage/unsolicited/powerfailure/PowerFailureMessageAppender.java
+++ b/jndc/src/main/java/io/github/jokoroukwu/jndc/terminal/statusmessage/unsolicited/powerfailure/PowerFailureMessageAppender.java
@@ -1,0 +1,50 @@
+package io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.powerfailure;
+
+import io.github.jokoroukwu.jndc.NdcCharBuffer;
+import io.github.jokoroukwu.jndc.terminal.ConfigurableNdcComponentAppender;
+import io.github.jokoroukwu.jndc.terminal.DeviceConfiguration;
+import io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.UnsolicitedStatusInformation;
+import io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.UnsolicitedStatusMessage;
+import io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.UnsolicitedStatusMessageBuilder;
+import io.github.jokoroukwu.jndc.trailingdata.TrailingDataChecker;
+import io.github.jokoroukwu.jndc.trailingdata.TrailingDataCheckerBase;
+import io.github.jokoroukwu.jndc.util.ObjectUtils;
+
+import static io.github.jokoroukwu.jndc.exception.NdcMessageParseException.onMessageParseError;
+import static io.github.jokoroukwu.jndc.exception.NdcMessageParseException.withMessage;
+import static io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.powerfailure.PowerFailure.COMMAND_NAME;
+
+public class PowerFailureMessageAppender implements ConfigurableNdcComponentAppender<UnsolicitedStatusMessageBuilder<UnsolicitedStatusInformation>> {
+    private final PowerFailureMessageListener messageListener;
+    private final TrailingDataChecker trailingDataChecker;
+
+    public PowerFailureMessageAppender(PowerFailureMessageListener messageListener, TrailingDataChecker trailingDataChecker) {
+        this.messageListener = ObjectUtils.validateNotNull(messageListener, "messageListener");
+        this.trailingDataChecker = ObjectUtils.validateNotNull(trailingDataChecker, "trailingDataChecker");
+    }
+
+    public PowerFailureMessageAppender(PowerFailureMessageListener messageListener) {
+        this(messageListener, TrailingDataCheckerBase.INSTANCE);
+    }
+
+    @Override
+    public void appendComponent(NdcCharBuffer ndcCharBuffer,
+                                UnsolicitedStatusMessageBuilder<UnsolicitedStatusInformation> stateObject,
+                                DeviceConfiguration deviceConfiguration) {
+
+        final int configurationId = ndcCharBuffer.tryReadInt(4)
+                .filter(val -> val <= 9999, val -> () -> "should be in range 0-9999 but was: " + val)
+                .getOrThrow(errorMessage -> withMessage(COMMAND_NAME, "Device Status", errorMessage, ndcCharBuffer));
+
+        trailingDataChecker.getErrorMessageOnTrailingData(ndcCharBuffer)
+                .ifPresent(errorMessage -> onMessageParseError(COMMAND_NAME, errorMessage, ndcCharBuffer));
+
+        final PowerFailure powerFailure = new PowerFailure(configurationId, null);
+        final UnsolicitedStatusMessageBuilder<? extends UnsolicitedStatusInformation> messageBuilder = stateObject
+                .withStatusInformation(powerFailure);
+
+        @SuppressWarnings("unchecked") final UnsolicitedStatusMessage<PowerFailure> powerFailureMessage
+                = (UnsolicitedStatusMessage<PowerFailure>) messageBuilder.build();
+        messageListener.onPowerFailureMessage(powerFailureMessage);
+    }
+}

--- a/jndc/src/main/java/io/github/jokoroukwu/jndc/terminal/statusmessage/unsolicited/powerfailure/PowerFailureMessageListener.java
+++ b/jndc/src/main/java/io/github/jokoroukwu/jndc/terminal/statusmessage/unsolicited/powerfailure/PowerFailureMessageListener.java
@@ -1,0 +1,8 @@
+package io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.powerfailure;
+
+import io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.UnsolicitedStatusMessage;
+
+public interface PowerFailureMessageListener {
+
+    void onPowerFailureMessage(UnsolicitedStatusMessage<PowerFailure> message);
+}

--- a/jndc/src/main/java/io/github/jokoroukwu/jndc/terminal/statusmessage/unsolicited/timeofdayclock/TimeOfDayClock.java
+++ b/jndc/src/main/java/io/github/jokoroukwu/jndc/terminal/statusmessage/unsolicited/timeofdayclock/TimeOfDayClock.java
@@ -3,7 +3,7 @@ package io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.timeofdaycl
 import io.github.jokoroukwu.jndc.terminal.TerminalMessageClass;
 import io.github.jokoroukwu.jndc.terminal.TerminalMessageSubClass;
 import io.github.jokoroukwu.jndc.terminal.dig.Dig;
-import io.github.jokoroukwu.jndc.terminal.statusmessage.devicefault.DeviceFault;
+import io.github.jokoroukwu.jndc.terminal.statusmessage.devicefault.DeviceStatusInformation;
 import io.github.jokoroukwu.jndc.terminal.statusmessage.devicefault.ErrorSeverity;
 import io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.UnsolicitedStatusInformation;
 import io.github.jokoroukwu.jndc.util.NdcStringBuilder;
@@ -12,21 +12,20 @@ import io.github.jokoroukwu.jndc.util.ObjectUtils;
 import java.util.Objects;
 import java.util.StringJoiner;
 
-public class TimeOfDayClockFailure implements DeviceFault, UnsolicitedStatusInformation {
-    public static final String COMMAND_NAME = TerminalMessageClass.UNSOLICITED + ": "
-            + TerminalMessageSubClass.STATUS_MESSAGE
-            + ": "
-            + Dig.TIME_OF_DAY_CLOCK;
+public class TimeOfDayClock implements DeviceStatusInformation, UnsolicitedStatusInformation {
+    public static final String COMMAND_NAME = TerminalMessageClass.UNSOLICITED
+            + ": " + TerminalMessageSubClass.STATUS_MESSAGE
+            + ": " + Dig.TIME_OF_DAY_CLOCK;
 
     private final ClockDeviceStatus deviceStatus;
     private final ErrorSeverity errorSeverity;
 
-    public TimeOfDayClockFailure(ClockDeviceStatus deviceStatus, ErrorSeverity errorSeverity) {
+    public TimeOfDayClock(ClockDeviceStatus deviceStatus, ErrorSeverity errorSeverity) {
         this.deviceStatus = ObjectUtils.validateNotNull(deviceStatus, "'Device Status'");
         this.errorSeverity = validateErrorSeverity(errorSeverity);
     }
 
-    TimeOfDayClockFailure(ClockDeviceStatus deviceStatus, ErrorSeverity errorSeverity, Void unused) {
+    TimeOfDayClock(ClockDeviceStatus deviceStatus, ErrorSeverity errorSeverity, Void unused) {
         this.deviceStatus = deviceStatus;
         this.errorSeverity = errorSeverity;
     }
@@ -56,7 +55,7 @@ public class TimeOfDayClockFailure implements DeviceFault, UnsolicitedStatusInfo
 
     @Override
     public String toString() {
-        return new StringJoiner(", ", TimeOfDayClockFailure.class.getSimpleName() + ": {", "}")
+        return new StringJoiner(", ", TimeOfDayClock.class.getSimpleName() + ": {", "}")
                 .add("deviceStatus: " + deviceStatus)
                 .add("errorSeverity: " + errorSeverity)
                 .toString();
@@ -66,7 +65,7 @@ public class TimeOfDayClockFailure implements DeviceFault, UnsolicitedStatusInfo
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        TimeOfDayClockFailure that = (TimeOfDayClockFailure) o;
+        TimeOfDayClock that = (TimeOfDayClock) o;
         return deviceStatus == that.deviceStatus && errorSeverity == that.errorSeverity;
     }
 

--- a/jndc/src/main/java/io/github/jokoroukwu/jndc/terminal/statusmessage/unsolicited/timeofdayclock/TimeOfDayClockFailureMessageListener.java
+++ b/jndc/src/main/java/io/github/jokoroukwu/jndc/terminal/statusmessage/unsolicited/timeofdayclock/TimeOfDayClockFailureMessageListener.java
@@ -4,5 +4,5 @@ import io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.UnsolicitedS
 
 public interface TimeOfDayClockFailureMessageListener {
 
-    void onTimeOfDayClockFailureMessage(UnsolicitedStatusMessage<TimeOfDayClockFailure> timeOfDayClockFailureMessage);
+    void onTimeOfDayClockStatusMessage(UnsolicitedStatusMessage<TimeOfDayClock> timeOfDayClockFailureMessage);
 }

--- a/jndc/src/main/java/io/github/jokoroukwu/jndc/trailingdata/TrailingDataChecker.java
+++ b/jndc/src/main/java/io/github/jokoroukwu/jndc/trailingdata/TrailingDataChecker.java
@@ -1,0 +1,10 @@
+package io.github.jokoroukwu.jndc.trailingdata;
+
+import io.github.jokoroukwu.jndc.NdcCharBuffer;
+
+import java.util.Optional;
+
+public interface TrailingDataChecker {
+
+    Optional<String> getErrorMessageOnTrailingData(NdcCharBuffer ndcCharBuffer);
+}

--- a/jndc/src/main/java/io/github/jokoroukwu/jndc/trailingdata/TrailingDataCheckerBase.java
+++ b/jndc/src/main/java/io/github/jokoroukwu/jndc/trailingdata/TrailingDataCheckerBase.java
@@ -1,0 +1,20 @@
+package io.github.jokoroukwu.jndc.trailingdata;
+
+import io.github.jokoroukwu.jndc.NdcCharBuffer;
+
+import java.util.Optional;
+
+public enum TrailingDataCheckerBase implements TrailingDataChecker {
+
+    INSTANCE;
+
+    @Override
+    public Optional<String> getErrorMessageOnTrailingData(NdcCharBuffer ndcCharBuffer) {
+        if (ndcCharBuffer.hasRemaining()) {
+            final int position = ndcCharBuffer.position();
+            final String remainingData = ndcCharBuffer.subBuffer().toString();
+            return Optional.of(String.format("unexpected trailing data at position %d: %s", position, remainingData));
+        }
+        return Optional.empty();
+    }
+}

--- a/jndc/src/test/java/io/github/jokoroukwu/jndc/central/datacommand/customisationdata/fitdataload/FitDataLoadCommandIntegrationTest.java
+++ b/jndc/src/test/java/io/github/jokoroukwu/jndc/central/datacommand/customisationdata/fitdataload/FitDataLoadCommandIntegrationTest.java
@@ -28,9 +28,7 @@ public class FitDataLoadCommandIntegrationTest implements CentralMessageListener
 
     @BeforeMethod
     public void setUp() {
-        deviceConfiguration = new DeviceConfigurationBase(false,
-                Set.of(),
-                ConfigurationOptions.EMPTY);
+        deviceConfiguration = new DeviceConfigurationBase(false, Set.of(), ConfigurationOptions.EMPTY);
         messagePreProcessor = new CentralMessagePreProcessor(this, this);
 
         messageBuffer = NdcCharBuffer.wrap(encodedMessage);

--- a/jndc/src/test/java/io/github/jokoroukwu/jndc/terminal/statusmessage/DeviceStatusInformationTest.java
+++ b/jndc/src/test/java/io/github/jokoroukwu/jndc/terminal/statusmessage/DeviceStatusInformationTest.java
@@ -15,7 +15,7 @@ import java.util.Map;
 
 import static org.mockito.Mockito.mock;
 
-public abstract class DeviceFaultTest {
+public abstract class DeviceStatusInformationTest {
     protected final TransactionCategoryCode dummyCurrencyCodeTlv = new TransactionCategoryCode("AB");
     protected final CompletionData dummyCompletionData = new CompletionData(Map.of(dummyCurrencyCodeTlv.getTag(), dummyCurrencyCodeTlv),
             List.of(new ScriptResult(ProcessingResult.SUCCESS, 1,

--- a/jndc/src/test/java/io/github/jokoroukwu/jndc/terminal/statusmessage/devicefault/DiagnosticStatusAppenderTest.java
+++ b/jndc/src/test/java/io/github/jokoroukwu/jndc/terminal/statusmessage/devicefault/DiagnosticStatusAppenderTest.java
@@ -2,7 +2,7 @@ package io.github.jokoroukwu.jndc.terminal.statusmessage.devicefault;
 
 import io.github.jokoroukwu.jndc.NdcCharBuffer;
 import io.github.jokoroukwu.jndc.terminal.ConfigurableNdcComponentAppender;
-import io.github.jokoroukwu.jndc.terminal.statusmessage.DeviceFaultTest;
+import io.github.jokoroukwu.jndc.terminal.statusmessage.DeviceStatusInformationTest;
 import io.github.jokoroukwu.jndc.terminal.statusmessage.devicefault.cardreader.CardReaderWriterFaultBuilder;
 import io.github.jokoroukwu.jndc.terminal.statusmessage.devicefault.diagnosticstatus.DiagnosticStatus;
 import io.github.jokoroukwu.jndc.terminal.statusmessage.devicefault.diagnosticstatus.DiagnosticStatusAppender;
@@ -17,7 +17,7 @@ import static io.github.jokoroukwu.jndc.util.text.Strings.EMPTY_STRING;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class DiagnosticStatusAppenderTest extends DeviceFaultTest {
+public class DiagnosticStatusAppenderTest extends DeviceStatusInformationTest {
     private final String minData = BmpStringGenerator.HEX.fixedLength(2);
     private final String arbitraryData = BmpStringGenerator.HEX.fixedLength(10);
     private ConfigurableNdcComponentAppender<CardReaderWriterFaultBuilder> nextAppenderMock;

--- a/jndc/src/test/java/io/github/jokoroukwu/jndc/terminal/statusmessage/devicefault/cardreaderwriter/CardReaderWriterFaultErrorSeveritiesAppenderTest.java
+++ b/jndc/src/test/java/io/github/jokoroukwu/jndc/terminal/statusmessage/devicefault/cardreaderwriter/CardReaderWriterFaultErrorSeveritiesAppenderTest.java
@@ -2,7 +2,7 @@ package io.github.jokoroukwu.jndc.terminal.statusmessage.devicefault.cardreaderw
 
 import io.github.jokoroukwu.jndc.NdcCharBuffer;
 import io.github.jokoroukwu.jndc.terminal.ConfigurableNdcComponentAppender;
-import io.github.jokoroukwu.jndc.terminal.statusmessage.DeviceFaultTest;
+import io.github.jokoroukwu.jndc.terminal.statusmessage.DeviceStatusInformationTest;
 import io.github.jokoroukwu.jndc.terminal.statusmessage.devicefault.ErrorSeverity;
 import io.github.jokoroukwu.jndc.terminal.statusmessage.devicefault.cardreader.CardReaderWriterErrorSeverityAppender;
 import io.github.jokoroukwu.jndc.terminal.statusmessage.devicefault.cardreader.CardReaderWriterFaultBuilder;
@@ -19,7 +19,7 @@ import java.util.List;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class CardReaderWriterFaultErrorSeveritiesAppenderTest extends DeviceFaultTest {
+public class CardReaderWriterFaultErrorSeveritiesAppenderTest extends DeviceStatusInformationTest {
 
     private CardReaderWriterErrorSeverityAppender appender;
     private CardReaderWriterFaultBuilder builder;

--- a/jndc/src/test/java/io/github/jokoroukwu/jndc/terminal/statusmessage/devicefault/cardreaderwriter/CardReaderWriterFaultSuppliesStatusAppenderTest.java
+++ b/jndc/src/test/java/io/github/jokoroukwu/jndc/terminal/statusmessage/devicefault/cardreaderwriter/CardReaderWriterFaultSuppliesStatusAppenderTest.java
@@ -2,7 +2,7 @@ package io.github.jokoroukwu.jndc.terminal.statusmessage.devicefault.cardreaderw
 
 import io.github.jokoroukwu.jndc.NdcCharBuffer;
 import io.github.jokoroukwu.jndc.terminal.ConfigurableNdcComponentAppender;
-import io.github.jokoroukwu.jndc.terminal.statusmessage.DeviceFaultTest;
+import io.github.jokoroukwu.jndc.terminal.statusmessage.DeviceStatusInformationTest;
 import io.github.jokoroukwu.jndc.terminal.statusmessage.devicefault.SuppliesStatus;
 import io.github.jokoroukwu.jndc.terminal.statusmessage.devicefault.cardreader.CardReaderWriterFaultBuilder;
 import io.github.jokoroukwu.jndc.terminal.statusmessage.devicefault.cardreader.CardReaderWriterSuppliesStatusAppender;
@@ -16,7 +16,7 @@ import org.testng.annotations.Test;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class CardReaderWriterFaultSuppliesStatusAppenderTest extends DeviceFaultTest {
+public class CardReaderWriterFaultSuppliesStatusAppenderTest extends DeviceStatusInformationTest {
     private CardReaderWriterFaultBuilder builder;
     private CardReaderWriterSuppliesStatusAppender appender;
 

--- a/jndc/src/test/java/io/github/jokoroukwu/jndc/terminal/statusmessage/devicefault/cardreaderwriter/CardReaderWriterFaultTest.java
+++ b/jndc/src/test/java/io/github/jokoroukwu/jndc/terminal/statusmessage/devicefault/cardreaderwriter/CardReaderWriterFaultTest.java
@@ -2,7 +2,7 @@ package io.github.jokoroukwu.jndc.terminal.statusmessage.devicefault.cardreaderw
 
 import io.github.jokoroukwu.jndc.terminal.completiondata.CompletionData;
 import io.github.jokoroukwu.jndc.terminal.dig.Dig;
-import io.github.jokoroukwu.jndc.terminal.statusmessage.DeviceFaultTest;
+import io.github.jokoroukwu.jndc.terminal.statusmessage.DeviceStatusInformationTest;
 import io.github.jokoroukwu.jndc.terminal.statusmessage.devicefault.ErrorSeverity;
 import io.github.jokoroukwu.jndc.terminal.statusmessage.devicefault.SuppliesStatus;
 import io.github.jokoroukwu.jndc.terminal.statusmessage.devicefault.cardreader.CardReaderWriterFault;
@@ -17,7 +17,7 @@ import org.testng.annotations.Test;
 
 import java.util.List;
 
-public class CardReaderWriterFaultTest extends DeviceFaultTest {
+public class CardReaderWriterFaultTest extends DeviceStatusInformationTest {
     private final Dig dig = Dig.MAGNETIC_CARD_READER_WRITER;
 
     private final ErrorSeverity dummyErrorSeverity = ErrorSeverity.NO_ERROR;

--- a/jndc/src/test/java/io/github/jokoroukwu/jndc/terminal/statusmessage/devicefault/cardreaderwriter/SolicitedCardReaderWriterFaultAppenderIntegrationTest.java
+++ b/jndc/src/test/java/io/github/jokoroukwu/jndc/terminal/statusmessage/devicefault/cardreaderwriter/SolicitedCardReaderWriterFaultAppenderIntegrationTest.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import static io.github.jokoroukwu.jndc.util.text.Strings.EMPTY_STRING;
 import static org.mockito.Mockito.*;
 
-public class SolicitedCardReaderWriterFaultAppenderIntegrationTest extends DeviceFaultTest {
+public class SolicitedCardReaderWriterFaultAppenderIntegrationTest extends DeviceStatusInformationTest {
     private final SolicitedStatusMessageBuilder<SolicitedStatusInformation> solicitedStatusMessageBuilder
             = new SolicitedStatusMessageBuilder<>()
             .withLuno(Luno.DEFAULT)

--- a/jndc/src/test/java/io/github/jokoroukwu/jndc/terminal/statusmessage/devicefault/cardreaderwriter/SolicitedCardReaderWriterFaultAppenderTest.java
+++ b/jndc/src/test/java/io/github/jokoroukwu/jndc/terminal/statusmessage/devicefault/cardreaderwriter/SolicitedCardReaderWriterFaultAppenderTest.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 import static org.mockito.Mockito.*;
 
-public class SolicitedCardReaderWriterFaultAppenderTest extends DeviceFaultTest {
+public class SolicitedCardReaderWriterFaultAppenderTest extends DeviceStatusInformationTest {
     private final SolicitedStatusMessageBuilder<SolicitedStatusInformation> solicitedStatusMessageBuilder
             = new SolicitedStatusMessageBuilder<>()
             .withLuno(Luno.DEFAULT)

--- a/jndc/src/test/java/io/github/jokoroukwu/jndc/terminal/statusmessage/devicefault/genericfault/GenericDeviceStatusInformationAppenderIntegrationTest.java
+++ b/jndc/src/test/java/io/github/jokoroukwu/jndc/terminal/statusmessage/devicefault/genericfault/GenericDeviceStatusInformationAppenderIntegrationTest.java
@@ -31,7 +31,7 @@ import static io.github.jokoroukwu.jndc.util.text.Strings.EMPTY_STRING;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-public class GenericDeviceFaultAppenderIntegrationTest {
+public class GenericDeviceStatusInformationAppenderIntegrationTest {
     private final Dig dig = Dig.MAGNETIC_CARD_READER_WRITER;
     private final SolicitedStatusMessageBuilder<SolicitedStatusInformation> solicitedDeviceFaultMeta
             = new SolicitedStatusMessageBuilder<>()

--- a/jndc/src/test/java/io/github/jokoroukwu/jndc/terminal/statusmessage/readyb/ReadyBStatusAppenderTest.java
+++ b/jndc/src/test/java/io/github/jokoroukwu/jndc/terminal/statusmessage/readyb/ReadyBStatusAppenderTest.java
@@ -22,7 +22,7 @@ import java.util.Optional;
 import static io.github.jokoroukwu.jndc.util.text.Strings.EMPTY_STRING;
 import static org.mockito.Mockito.*;
 
-public class ReadyBStatusAppenderTest extends DeviceFaultTest {
+public class ReadyBStatusAppenderTest extends DeviceStatusInformationTest {
     private final TransactionData<? extends Cassette> transactionData
             = TransactionData.depositData(new CdmRecycleCassette(1, 1,
             BmpStringGenerator.HEX.fixedLength(10)));

--- a/jndc/src/test/java/io/github/jokoroukwu/jndc/terminal/statusmessage/unsolicited/UnsolicitedMessageAppenderTest.java
+++ b/jndc/src/test/java/io/github/jokoroukwu/jndc/terminal/statusmessage/unsolicited/UnsolicitedMessageAppenderTest.java
@@ -2,6 +2,7 @@ package io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited;
 
 import io.github.jokoroukwu.jndc.Luno;
 import io.github.jokoroukwu.jndc.terminal.DeviceConfiguration;
+import io.github.jokoroukwu.jndc.trailingdata.TrailingDataChecker;
 import org.testng.annotations.BeforeClass;
 
 import static org.mockito.Mockito.mock;
@@ -9,9 +10,11 @@ import static org.mockito.Mockito.mock;
 public abstract class UnsolicitedMessageAppenderTest {
     protected DeviceConfiguration deviceConfigurationMock;
     protected UnsolicitedStatusMessageBuilder<UnsolicitedStatusInformation> messageBuilder;
+    protected TrailingDataChecker trailingDataCheckerMock;
 
     @BeforeClass
     public void baseSetUp() {
+        trailingDataCheckerMock = mock(TrailingDataChecker.class);
         deviceConfigurationMock = mock(DeviceConfiguration.class);
         messageBuilder = new UnsolicitedStatusMessageBuilder<>()
                 .withLuno(Luno.DEFAULT);

--- a/jndc/src/test/java/io/github/jokoroukwu/jndc/terminal/statusmessage/unsolicited/powerfailure/PowerFailureMessageAppenderTest.java
+++ b/jndc/src/test/java/io/github/jokoroukwu/jndc/terminal/statusmessage/unsolicited/powerfailure/PowerFailureMessageAppenderTest.java
@@ -1,0 +1,63 @@
+package io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.powerfailure;
+
+import io.github.jokoroukwu.jndc.Luno;
+import io.github.jokoroukwu.jndc.NdcCharBuffer;
+import io.github.jokoroukwu.jndc.exception.NdcMessageParseException;
+import io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.UnsolicitedMessageAppenderTest;
+import io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.UnsolicitedStatusMessage;
+import io.github.jokoroukwu.jndc.util.text.stringgenerator.BmpStringGenerator;
+import org.assertj.core.api.Assertions;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.*;
+
+public class PowerFailureMessageAppenderTest extends UnsolicitedMessageAppenderTest {
+    private final String configurationId = "0000";
+    private PowerFailureMessageAppender appender;
+    private PowerFailureMessageListener messageListenerMock;
+    private NdcCharBuffer buffer;
+
+    @BeforeClass
+    public void beforeClass() {
+        messageListenerMock = mock(PowerFailureMessageListener.class);
+        appender = new PowerFailureMessageAppender(messageListenerMock, trailingDataCheckerMock);
+    }
+
+    @BeforeMethod
+    public void setUp() {
+        buffer = NdcCharBuffer.wrap(configurationId);
+    }
+
+    @Test
+    public void should_append_expected_message() {
+        when(trailingDataCheckerMock.getErrorMessageOnTrailingData(any()))
+                .thenReturn(Optional.empty());
+        appender.appendComponent(buffer, messageBuilder, deviceConfigurationMock);
+
+        final UnsolicitedStatusMessage<PowerFailure> expectedMessage = new UnsolicitedStatusMessage<>(Luno.DEFAULT,
+                new PowerFailure(Integer.parseInt(configurationId)));
+
+        verify(messageListenerMock, times(1))
+                .onPowerFailureMessage(expectedMessage);
+
+        verifyNoInteractions(deviceConfigurationMock);
+
+        verify(trailingDataCheckerMock, times(1))
+                .getErrorMessageOnTrailingData(buffer);
+    }
+
+    @Test
+    public void should_throw_expected_exception_on_trailing_data_error() {
+        final String trailingDataErrorMessage = BmpStringGenerator.ofCharacterRange('a', 'z').fixedLength(10);
+        when(trailingDataCheckerMock.getErrorMessageOnTrailingData(any()))
+                .thenReturn(Optional.of(trailingDataErrorMessage));
+
+        Assertions.assertThatThrownBy(() -> appender.appendComponent(buffer, messageBuilder, deviceConfigurationMock))
+                .isInstanceOf(NdcMessageParseException.class)
+                .hasMessageContaining(trailingDataErrorMessage);
+    }
+}

--- a/jndc/src/test/java/io/github/jokoroukwu/jndc/terminal/statusmessage/unsolicited/powerfailure/PowerFailureMessageIntegrationTest.java
+++ b/jndc/src/test/java/io/github/jokoroukwu/jndc/terminal/statusmessage/unsolicited/powerfailure/PowerFailureMessageIntegrationTest.java
@@ -1,4 +1,4 @@
-package io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.timeofdayclock;
+package io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.powerfailure;
 
 import io.github.jokoroukwu.jndc.NdcCharBuffer;
 import io.github.jokoroukwu.jndc.terminal.*;
@@ -10,10 +10,10 @@ import org.testng.annotations.Test;
 
 import java.util.Set;
 
-public class TimeOfDayClockIntegrationTest implements TerminalMessageListener, DeviceConfigurationSupplier<TerminalMessageMeta> {
+public class PowerFailureMessageIntegrationTest implements TerminalMessageListener, DeviceConfigurationSupplier<TerminalMessageMeta> {
     private final TerminalMessagePreProcessor messagePreProcessor = new TerminalMessagePreProcessor(this, this);
-    private final String rawMessage = "12\u001C324123456\u001C\u001CA24";
-    private UnsolicitedStatusMessage<TimeOfDayClock> message;
+    private final String rawMessage = "12\u001C324123456\u001C\u001CB0000";
+    private UnsolicitedStatusMessage<PowerFailure> message;
     private NdcCharBuffer buffer;
 
     @BeforeClass
@@ -23,7 +23,7 @@ public class TimeOfDayClockIntegrationTest implements TerminalMessageListener, D
     }
 
     @Override
-    public void onTimeOfDayClockStatusMessage(UnsolicitedStatusMessage<TimeOfDayClock> message) {
+    public void onPowerFailureMessage(UnsolicitedStatusMessage<PowerFailure> message) {
         this.message = message;
     }
 

--- a/jndc/src/test/java/io/github/jokoroukwu/jndc/terminal/statusmessage/unsolicited/powerfailure/PowerFailureTest.java
+++ b/jndc/src/test/java/io/github/jokoroukwu/jndc/terminal/statusmessage/unsolicited/powerfailure/PowerFailureTest.java
@@ -1,0 +1,43 @@
+package io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.powerfailure;
+
+import io.github.jokoroukwu.jndc.terminal.dig.Dig;
+import io.github.jokoroukwu.jndc.util.Integers;
+import org.assertj.core.api.Assertions;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class PowerFailureTest {
+
+    @DataProvider
+    public Object[][] invalidConfigIdProvider() {
+        return new Object[][]{
+                {-1},
+                {10000}
+        };
+    }
+
+    @Test(dataProvider = "invalidConfigIdProvider")
+    public void should_throw_expected_exception_on_invalid_config_id(int invalidConfigId) {
+        Assertions.assertThatThrownBy(()-> new PowerFailure(invalidConfigId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Configuration ID");
+    }
+
+
+    @DataProvider
+    public Object[][] validConfigIdProvider() {
+        return new Object[][]{
+                {0},
+                {9999}
+        };
+    }
+
+    @Test(dataProvider = "validConfigIdProvider")
+    public void should_return_expected_ndc_string(int configId) {
+        final String actualNdcString = new PowerFailure(configId).toNdcString();
+        final String expectedNdcString = Dig.COMMUNICATIONS.toNdcString() + Integers.toZeroPaddedString(configId, 4);
+
+        Assertions.assertThat(actualNdcString)
+                .isEqualTo(expectedNdcString);
+    }
+}

--- a/jndc/src/test/java/io/github/jokoroukwu/jndc/terminal/statusmessage/unsolicited/timeofdayclock/TimeOfDayClockTest.java
+++ b/jndc/src/test/java/io/github/jokoroukwu/jndc/terminal/statusmessage/unsolicited/timeofdayclock/TimeOfDayClockTest.java
@@ -9,7 +9,7 @@ import org.testng.annotations.Test;
 import java.util.EnumSet;
 import java.util.Iterator;
 
-public class TimeOfDayClockFailureTest {
+public class TimeOfDayClockTest {
 
     @DataProvider
     public Iterator<Object[]> invalidErrorSeverityProvider() {
@@ -21,14 +21,14 @@ public class TimeOfDayClockFailureTest {
 
     @Test(dataProvider = "invalidErrorSeverityProvider")
     public void should_throw_expected_exception_on_invalid_error_severity(ErrorSeverity invalidErrorSeverity) {
-        Assertions.assertThatThrownBy(() -> new TimeOfDayClockFailure(ClockDeviceStatus.RESET, invalidErrorSeverity))
+        Assertions.assertThatThrownBy(() -> new TimeOfDayClock(ClockDeviceStatus.RESET, invalidErrorSeverity))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Error Severity");
     }
 
     @Test
     public void should_return_expected_ndc_string() {
-        final String actualNdcString = new TimeOfDayClockFailure(ClockDeviceStatus.STOPPED, ErrorSeverity.FATAL).toNdcString();
+        final String actualNdcString = new TimeOfDayClock(ClockDeviceStatus.STOPPED, ErrorSeverity.FATAL).toNdcString();
         final String expectedNdcString = Dig.TIME_OF_DAY_CLOCK.getValue() + "2" + ErrorSeverity.FATAL.getValue();
 
         Assertions.assertThat(actualNdcString)


### PR DESCRIPTION
 * DeviceFault.java interface renamed to DeviceStatusInformation.java
 * Added 'Power Failure' message data objects and appender to io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.powerfailure
 * TerminalMessageListener now implements PowerFailureMessageListener
 * Added corresponding tests
 * Added 'PowerFailure Failure' consume example to LoggingTerminalMessageListener