### PR TITLE
Fix TimeOfDayClock.toNdcString()

### DIFF
--- a/jndc/src/main/java/io/github/jokoroukwu/jndc/terminal/statusmessage/unsolicited/timeofdayclock/TimeOfDayClock.java
+++ b/jndc/src/main/java/io/github/jokoroukwu/jndc/terminal/statusmessage/unsolicited/timeofdayclock/TimeOfDayClock.java
@@ -43,6 +43,7 @@ public class TimeOfDayClock implements DeviceStatusInformation, UnsolicitedStatu
         return new NdcStringBuilder(3)
                 .appendComponent(Dig.TIME_OF_DAY_CLOCK)
                 .appendComponent(deviceStatus)
+                .appendFs()
                 .appendComponent(errorSeverity)
                 .toString();
     }

--- a/jndc/src/test/java/io/github/jokoroukwu/jndc/terminal/statusmessage/unsolicited/timeofdayclock/TimeOfDayClockIntegrationTest.java
+++ b/jndc/src/test/java/io/github/jokoroukwu/jndc/terminal/statusmessage/unsolicited/timeofdayclock/TimeOfDayClockIntegrationTest.java
@@ -12,7 +12,7 @@ import java.util.Set;
 
 public class TimeOfDayClockIntegrationTest implements TerminalMessageListener, DeviceConfigurationSupplier<TerminalMessageMeta> {
     private final TerminalMessagePreProcessor messagePreProcessor = new TerminalMessagePreProcessor(this, this);
-    private final String rawMessage = "12\u001C324123456\u001C\u001CA24";
+    private final String rawMessage = "12\u001C324123456\u001C\u001CA2\u001C4";
     private UnsolicitedStatusMessage<TimeOfDayClock> message;
     private NdcCharBuffer buffer;
 

--- a/jndc/src/test/java/io/github/jokoroukwu/jndc/terminal/statusmessage/unsolicited/timeofdayclock/TimeOfDayClockTest.java
+++ b/jndc/src/test/java/io/github/jokoroukwu/jndc/terminal/statusmessage/unsolicited/timeofdayclock/TimeOfDayClockTest.java
@@ -2,6 +2,7 @@ package io.github.jokoroukwu.jndc.terminal.statusmessage.unsolicited.timeofdaycl
 
 import io.github.jokoroukwu.jndc.terminal.dig.Dig;
 import io.github.jokoroukwu.jndc.terminal.statusmessage.devicefault.ErrorSeverity;
+import io.github.jokoroukwu.jndc.util.NdcConstants;
 import org.assertj.core.api.Assertions;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -29,7 +30,10 @@ public class TimeOfDayClockTest {
     @Test
     public void should_return_expected_ndc_string() {
         final String actualNdcString = new TimeOfDayClock(ClockDeviceStatus.STOPPED, ErrorSeverity.FATAL).toNdcString();
-        final String expectedNdcString = Dig.TIME_OF_DAY_CLOCK.getValue() + "2" + ErrorSeverity.FATAL.getValue();
+        final String expectedNdcString = Dig.TIME_OF_DAY_CLOCK.getValue()
+                + "2"
+                + NdcConstants.FIELD_SEPARATOR
+                + ErrorSeverity.FATAL.getValue();
 
         Assertions.assertThat(actualNdcString)
                 .isEqualTo(expectedNdcString);


### PR DESCRIPTION
 * toNdcString() now properly prepends error severity field with a field separator character
 * TimeOfDayClockTest and TimeOfDayClockIntegrationTest adjusted accordingly